### PR TITLE
workflows/nomination.yml: ignore PRs that only touch eligible.csv

### DIFF
--- a/.github/workflows/nomination.yml
+++ b/.github/workflows/nomination.yml
@@ -3,6 +3,8 @@ name: "Nomination PRs"
 on:
   pull_request_target:
     types: [edited, opened, synchronize, reopened]
+    paths-ignore:
+      - eligible.csv
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
This prevents every PR adding emails to eligible.csv from failing CI. (I'm not sure when this *is* supposed to run, or if using `paths` would be sufficient. But I'm pretty sure it's *not* supposed to run on PRs that only touch eligible.csv.)

See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths for documentation on paths-ignore.