### PR TITLE
workflows/update-email.yml: ignore PRs that do not touch eligible.csv

### DIFF
--- a/.github/workflows/update-email.yml
+++ b/.github/workflows/update-email.yml
@@ -2,6 +2,8 @@ name: "Email updates"
 
 on:
   pull_request_target:
+    paths:
+      - eligible.csv
 
 jobs:
   automerge:


### PR DESCRIPTION
This prevents this job from running (and failing) on PRs like this one. (It won't help this one, because the workflow uses `pull_request_target`.)

See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-paths for the semantics of `paths`.