### PR TITLE
Add e-mail for Janik-Haag on their behalf

### DIFF
--- a/eligible.csv
+++ b/eligible.csv
@@ -944,7 +944,7 @@ githubId,githubUsername,email
 78392041,winterqt,
 78693624,llakala,elevenaka11@gmail.com
 79252025,panicgh,
-80165193,Janik-Haag,
+80165193,Janik-Haag,janik@aq0.de
 81317317,auroraanna,
 81340136,polykernel,
 81826728,stepbrobd,ysun@hey.com


### PR DESCRIPTION
Note: I am adding this e-mail on behalf of Janik, because they can not create any public PRs or issue comments for private reasons. The person merging this is free to confirm with Janik in private.