### PR TITLE
Add my (marius851000) vote mail address

### DIFF
--- a/eligible.csv
+++ b/eligible.csv
@@ -704,7 +704,7 @@ githubId,githubUsername,email
 22363274,ryan4yin,ryan4yin@linux.com
 22406910,pluiedev,hi@pluie.me
 22500027,usertam,
-22586596,marius851000,
+22586596,marius851000,nixvote@mariusdavid.fr
 22727114,Infinidoge,
 22803888,wineee,
 22817873,n0emis,


### PR DESCRIPTION
So I need to manually add an e-mail? I would have preferred not having to do that. Otherwise, not sure I'll vote.

(ps: I have a catchall domain for mail)