### PR TITLE
eligible.csv: add email of Yarny0 (=myself)

### DIFF
--- a/eligible.csv
+++ b/eligible.csv
@@ -816,7 +816,7 @@ githubId,githubUsername,email
 41458459,yzx9,
 41522204,hexchen,nix@nixwit.ch
 41747605,Defelo,mail@defelo.de
-41838844,Yarny0,
+41838844,Yarny0,Yarny-OnlyForNixosElection2024@public-files.de
 41924494,IvarWithoutBones,
 42114389,JerrySM64,
 42209822,Aleksanaa,me@aleksana.moe


### PR DESCRIPTION
I'm reusing the address from last year's election, so that email address is correct
although the address itself says otherwise.