### PR TITLE
Candidate statement: K900: remove mistakenly put answer in Q&A

### DIFF
--- a/candidates/K900.md
+++ b/candidates/K900.md
@@ -256,38 +256,6 @@ I am curious to hear your thoughts.
 Oh boy do I have thoughts on documentation. Unfortunately, most of my thoughts on documentation are "we need a strong editorial voice" followed by a lot of half-formed ideas of what that voice should be like and a disappointing realization that I will never find enough spoons to actually finish any of it myself. From the SC side of things, I think the best thing we can do is find people that are willing to be that strong editorial voice, and make sure they can do their thing, whether that involves setting up new infra, putting them in touch with teams with relevant technical expertise, or handling whatever formalities may come up wrt trademarks and such.
 </details>
 
-### What is a "competing implementation", and should being involved in one constitute a conflict of interest? ([link](https://github.com/NixOS/SC-election-2025/issues/456))
-
-
-(This is a little targeted, though everyone is welcome to chime in with their thoughts, of course.)
-
-In https://github.com/NixOS/SC-election-2025/issues/192#issuecomment-3354754312 you said that you're worried about the current definition of "conflict of interest" not including "being involved in competing implementations and communities, social media groups, country, military status, and so forth".
-
-What is a "competing implementation" or "competing community" to you? What level of involvement would you consider significant enough to constitute CoI? What decisions are you expecting the SC to make where this CoI becomes an issue?
-
-Also, once again, as a litmus test, would any of these people be considered to have a CoI?
-- a Lix/Snix/Tvix/etc team member
-- a Determinate Systems employee
-- a Snix/Tvix/Lix/etc contributor
-- a contibutor to both NixOS/nix and Lix/Snix/Tvix/etc
-- a person present in Tvix/Snix/Lix/etc discussion spaces
-- an Auxolotl/Ekala/etc contributor
-- a contributor to both NixOS/nixpkgs and Ekala/Auxolotl/etc
-- a person present in Auxolotl/Ekala/etc discussion spaces
-
-Also, can you maybe name examples of social media groups or countries that would be considered to have a CoI, and why/when?
-
-<details>
-<summary>Answer (<a href="https://github.com/NixOS/SC-election-2025/issues/456#issuecomment-3355026472">link</a>)</summary>
-
-> > Also, once again, as a litmus test, would any of these people be considered to have a CoI?
-> 
-> Yep!
-> 
-
-Just to clarify, all of them? If not, which ones and why? 
-</details>
-
 ## Unanswered questions
 <details>
 <summary>Course of action for nixos.wiki (<a href="https://github.com/NixOS/SC-election-2025/issues/474">link</a>)</summary>
@@ -542,6 +510,27 @@ That's why SC members need a lot more autonomy, to be able to make decisions on 
 Considering this, how would you reform the SC to allow for more individual action and autonomy?
 
 c.f. #261
+</details>
+<details>
+<summary>What is a "competing implementation", and should being involved in one constitute a conflict of interest? (<a href="https://github.com/NixOS/SC-election-2025/issues/456">link</a>)</summary>
+
+(This is a little targeted, though everyone is welcome to chime in with their thoughts, of course.)
+
+In https://github.com/NixOS/SC-election-2025/issues/192#issuecomment-3354754312 you said that you're worried about the current definition of "conflict of interest" not including "being involved in competing implementations and communities, social media groups, country, military status, and so forth".
+
+What is a "competing implementation" or "competing community" to you? What level of involvement would you consider significant enough to constitute CoI? What decisions are you expecting the SC to make where this CoI becomes an issue?
+
+Also, once again, as a litmus test, would any of these people be considered to have a CoI?
+- a Lix/Snix/Tvix/etc team member
+- a Determinate Systems employee
+- a Snix/Tvix/Lix/etc contributor
+- a contibutor to both NixOS/nix and Lix/Snix/Tvix/etc
+- a person present in Tvix/Snix/Lix/etc discussion spaces
+- an Auxolotl/Ekala/etc contributor
+- a contributor to both NixOS/nixpkgs and Ekala/Auxolotl/etc
+- a person present in Auxolotl/Ekala/etc discussion spaces
+
+Also, can you maybe name examples of social media groups or countries that would be considered to have a CoI, and why/when?
 </details>
 <details>
 <summary>Currently sitting SC members running for reelection: why did you vote the way you did on a vote of no confidence on 2025-09-30? (<a href="https://github.com/NixOS/SC-election-2025/issues/452">link</a>)</summary>


### PR DESCRIPTION
K900 themselves asked https://github.com/NixOS/SC-election-2025/issues/456, and their comment was just a reply to another candidate's reply. The bot mistakenly assumed it was an answer to that question.