### PR TITLE
readme: clarification for AoE timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ After the question has been posted, only candidates and nominees can respond to 
 
 We will make an effort to regularly, once per 3 days or more often, upload the later registrations to OpaVote, but this will be manual and not in real time»
 
-Voting end date is AoE: you can vote as long as anywhere on the Earth (latest timezone on the Earth is equivalent to UTC-12, the zone that is 12 hours behind UTC year-round) it is still 2025-11-01.
+Voting end date is 2025-11-01 *Anywhere on Earth* (AoE, UTC-12), which is the most delayed timezone.
+This means if your (local) clock shows 2025-11-01 or an earlier date you can still vote.
+If your (local) clock shows 2025-11-02 (one day after the end date) you *may* still be able to vote but you will have to compare timezones[^timezone-command] to be sure.
+
+[^timezone-command]: `env TZ=Etc/GMT+12 date --rfc-3339=s` will give you the relvevant AoE time and date.
+As long as *the date portion* still displays 2025-11-01 or earlier this means you can still vote.
+Any time left before the following day (2025-11-02) is the time left for voting.
 
 ## Election Committee (EC)
 


### PR DESCRIPTION
While the language around that timezone tends to be correct in Nix related spaces, it is also not very intuitive IMHO. The "latest timezone" phrase is technically correct, but hard to parse given the modern usage of "latest" (read: most recent) in tech as the concept does not map 1:1.

With these changes there is a very clear description of "what you see on the clock" vs. "what that means about voting", which should clarify 95% of use-cases, with the last 5% of cases (voters checking within the last 24h) being deferred into a footnote with a shell command that should work virtually everywhere.

---

Above is the commit message verbatim.

AoE always trips me up because I never remember if it is UTC+12 or UTC-12, and making the wording absolutely clear, and giving instructions on how to double check if needed is probably a good idea.
Short of a flowchart this is probably the most clear wording I can come up with.

Please note that this PR is *very* opinionated.
Feel free to decline or suggest changes, as long as it doesn't turn into bikeshedding (*if* this is merged, it should be merged before that date after all).

As an aside, it would be great if other documents (such as the NixOS releng stuff like the tracking issue with the timetable) could also adopt something like this.
Timezones are hard, and with the idea of AoE being ease of use we should probably push that ease of use.
As a rule of thumb; if people have to look up timezones after reading the text on the page that states the timezone, then choosing AoE gains nothing over UTC (which is usually easier to convert to since most timezones are given as a UTC offset).

Again: *opinionated* PR, I can't state that clearly enough.